### PR TITLE
Update branch requirement for identification examples

### DIFF
--- a/identification/Config.xml
+++ b/identification/Config.xml
@@ -3,6 +3,6 @@
     <TwoEarsPart sub="src" startup="startBinauralSimulator">binaural-simulator</TwoEarsPart>
     <TwoEarsPart branch="master"             startup="startAuditoryFrontEnd">auditory-front-end</TwoEarsPart>
     <TwoEarsPart branch="master" startup="startBlackboardSystem">blackboard-system</TwoEarsPart>
-    <TwoEarsPart branch="r1.2" startup="startIdentificationTraining">identification-training</TwoEarsPart>
+    <TwoEarsPart branch="master" startup="startIdentificationTraining">identification-training</TwoEarsPart>
     <TwoEarsPart sub="API_MO" startup="SOFAstart">sofa</TwoEarsPart>
 </requirements>

--- a/train_identification_model/Config.xml
+++ b/train_identification_model/Config.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <requirements>
-<TwoEarsPart branch="r1.2" startup="startIdentificationTraining">identification-training</TwoEarsPart>
+<TwoEarsPart branch="master" startup="startIdentificationTraining">identification-training</TwoEarsPart>
 </requirements>


### PR DESCRIPTION
The `identification` and `train_identification_model` examples both require the "r1.2" branch of the identification-training-pipeline.
Since branch "r1.2" doesn't exist, I'm switching the requirement to 'master'.
