### PR TITLE
fix dnn localization configs to successfully load model files.

### DIFF
--- a/localisation_DNNs/BlackboardDnn.xml
+++ b/localisation_DNNs/BlackboardDnn.xml
@@ -6,7 +6,8 @@
     </dataConnection>
 
     <KS Name="loc" Type="DnnLocationKS">
-        <Param Type="int">16</Param>
+        <Param Type="char">MCT-DIFFUSE</Param>
+        <Param Type="int">32</Param>
     </KS>
     <KS Name="conf" Type="ConfusionKS"/>
     <KS Name="confSolv" Type="ConfusionSolvingKS"/>

--- a/localisation_DNNs/BlackboardDnnNoHeadRotation.xml
+++ b/localisation_DNNs/BlackboardDnnNoHeadRotation.xml
@@ -6,7 +6,8 @@
     </dataConnection>
 
     <KS Name="loc" Type="DnnLocationKS">
-        <Param Type="int">16</Param>
+        <Param Type="char">MCT-DIFFUSE-FRONT</Param>
+        <Param Type="int">32</Param>
     </KS>
     <KS Name="conf" Type="ConfusionKS">
         <!-- Disable confusion solving (== no head rotation) -->


### PR DESCRIPTION
In the localization_DNNs example:
The current xml configuration for building the blackboard system leads to invalid download requests for model files. It basically tries to download files for the dnn model that don't exist.

This adds a preset parameter and changes the no. of channels in the xlms so that it directs it to model files that exist in the database.

Not sure if those are the preferred models, would need to get Ning's confirmation.
